### PR TITLE
FEC-9918 add NPE for null file give as paramater to getWidevineInitData

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -201,6 +201,10 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     public DrmStatus getDrmStatus(@NonNull String assetId) {
         try {
             final byte[] drmInitData = getDrmInitData(assetId);
+            if (drmInitData == null) {
+                log.e("getDrmStatus failed drmInitData = null");
+                return DrmStatus.unknown;
+            }
             return getDrmStatus(assetId, drmInitData);
 
         } catch (IOException | InterruptedException e) {
@@ -215,6 +219,10 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     public void renewDrmAssetLicense(@NonNull String assetId, @NonNull PKDrmParams drmParams) {
         try {
             final byte[] drmInitData = getDrmInitData(assetId);
+            if (drmInitData == null) {
+                postEvent(() -> getListener().onRegisterError(assetId, new LocalAssetsManager.RegisterException("drmInitData = null", null)));
+                return;
+            }
             lam.registerWidevineDashAsset(assetId, drmParams.getLicenseUri(), drmInitData);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, drmInitData)));
         } catch (LocalAssetsManager.RegisterException | IOException | InterruptedException e) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -189,6 +189,9 @@ public class DTGOfflineManager extends AbstractOfflineManager {
     @Override
     protected byte[] getDrmInitData(String assetId) throws IOException {
         final File localFile = cm.getLocalFile(assetId);
+        if (localFile == null) {
+            return null;
+        }
         return getWidevineInitData(localFile);
     }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/exo/ExoOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/exo/ExoOfflineManager.java
@@ -539,6 +539,11 @@ public class ExoOfflineManager extends AbstractOfflineManager {
     public boolean removeAsset(@NonNull String assetId) {
         try {
             final byte[] drmInitData = getDrmInitData(assetId);
+            if (drmInitData == null) {
+                log.e("removeAsset failed");
+                return false;
+            }
+
             lam.unregisterAsset(assetId, drmInitData);
             DownloadService.sendRemoveDownload(appContext, ExoDownloadService.class, assetId, false);
             removeAssetSourceId(assetId);


### PR DESCRIPTION
    protected byte[] getDrmInitData(String assetId) throws IOException {
        final File localFile = cm.getLocalFile(assetId);
        if (localFile == null) {
            return null;
        }
        return getWidevineInitData(localFile);
    }
