### PR TITLE
FEC-9915 Countdown timer doesn't works for last entry when loop enabled

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
@@ -355,6 +355,7 @@ public class PKPlaylistController implements PlaylistController {
     @Override
     public void playNext() {
         log.d("playNext");
+        kalturaPlayer.pause();
         int playlistSize = playlist.getMediaListSize();
         if (currentPlayingIndex + 1 == playlistSize) {
             if (loopEnabled) {
@@ -382,6 +383,7 @@ public class PKPlaylistController implements PlaylistController {
     @Override
     public void playPrev() {
         log.d("playPrev");
+        kalturaPlayer.pause();
         int playlistSize = playlist.getMediaListSize();
         if (currentPlayingIndex - 1 < 0) {
             if (loopEnabled) {
@@ -652,7 +654,6 @@ public class PKPlaylistController implements PlaylistController {
                         playlistCountDownOptions.setShouldDisplay(false);
                         return;
                     }
-                    kalturaPlayer.pause();
                     handlePlaylistMediaEnded();
                 }
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
@@ -576,6 +576,7 @@ public class PKPlaylistController implements PlaylistController {
                 long fixedTimeToShow = (tmpCountDownOptions.getTimeToShowMS() == -1) ? event.duration - tmpCountDownOptions.getDurationMS() : tmpCountDownOptions.getTimeToShowMS();
                 playlistCountDownOptions = new CountDownOptions(fixedTimeToShow, tmpCountDownOptions.getDurationMS(), tmpCountDownOptions.shouldDisplay());
 
+                // in case of seek after ended event and last media in list no loop
                 int playlistSize = playlist.getMediaListSize();
                 boolean isLastMediaInPlaylist = ((currentPlayingIndex + 1) == playlistSize);
                 if (isLastMediaInPlaylist && !loopEnabled) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
@@ -575,16 +575,6 @@ public class PKPlaylistController implements PlaylistController {
                 }
                 long fixedTimeToShow = (tmpCountDownOptions.getTimeToShowMS() == -1) ? event.duration - tmpCountDownOptions.getDurationMS() : tmpCountDownOptions.getTimeToShowMS();
                 playlistCountDownOptions = new CountDownOptions(fixedTimeToShow, tmpCountDownOptions.getDurationMS(), tmpCountDownOptions.shouldDisplay());
-
-                // in case of seek after ended event and last media in list no loop
-                int playlistSize = playlist.getMediaListSize();
-                boolean isLastMediaInPlaylist = ((currentPlayingIndex + 1) == playlistSize);
-                if (isLastMediaInPlaylist && !loopEnabled) {
-                    if (event.position > playlistCountDownOptions.getTimeToShowMS()) {
-                        playlistCountDownOptions.setTimeToShowMS(event.position);
-                        return;
-                    }
-                }
             }
 
             if (event.position >= event.duration) {
@@ -649,21 +639,19 @@ public class PKPlaylistController implements PlaylistController {
                 }
                 int playlistSize = playlist.getMediaListSize();
                 boolean isLastMediaInPlaylist = ((currentPlayingIndex + 1) == playlistSize);
+
+                if (isLastMediaInPlaylist && !loopEnabled) {
+                   return;
+                }
+
                 if (!playlistCountDownOptions.isEventSent()) {
                     log.d("SEND COUNT DOWN EVENT position = " + event.position);
                     kalturaPlayer.getMessageBus().post(new PlaylistEvent.PlaylistCountDownStart(currentPlayingIndex, playlistCountDownOptions));
                     playlistCountDownOptions.setEventSent(true);
-
-                    if (!isLastMediaInPlaylist || loopEnabled) {
-                        preloadNext();
-                    }
+                    preloadNext();
                 } else if (event.position >= Math.min(playlistCountDownOptions.getTimeToShowMS() + playlistCountDownOptions.getDurationMS(), event.duration)) {
                     kalturaPlayer.getMessageBus().post(new PlaylistEvent.PlaylistCountDownEnd(currentPlayingIndex, playlistCountDownOptions));
                     //log.d("playhead updated handlePlaylistMediaEnded");
-                    if (isLastMediaInPlaylist && !loopEnabled) {
-                        playlistCountDownOptions.setShouldDisplay(false);
-                        return;
-                    }
                     handlePlaylistMediaEnded();
                 }
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
@@ -26,11 +26,9 @@ import com.kaltura.tvplayer.playlist.PlaylistEvent;
 import com.kaltura.tvplayer.playlist.PlaylistOptions;
 
 import java.util.ArrayList;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 
 public class PKPlaylistController implements PlaylistController {
 
@@ -102,6 +100,10 @@ public class PKPlaylistController implements PlaylistController {
     @Override
     public void preloadNext() {
         if (kalturaPlayer.getTvPlayerType() != KalturaPlayer.Type.basic) {
+            if (playlist != null && currentPlayingIndex + 1 == playlist.getMediaListSize()) {
+                preloadItem(0);
+                return;
+            }
             preloadItem(currentPlayingIndex + 1);
         }
     }
@@ -555,7 +557,7 @@ public class PKPlaylistController implements PlaylistController {
 
         kalturaPlayer.addListener(this, PlayerEvent.playheadUpdated, event -> {
             //log.d("playheadUpdated received position = " + event.position + "/" + event.duration);
-
+            
             if (playlistCountDownOptions == null) {
                 CountDownOptions tmpCountDownOptions = null;
                 if (playlistOptions instanceof OVPPlaylistOptions) {
@@ -628,19 +630,29 @@ public class PKPlaylistController implements PlaylistController {
     }
 
     private void handleCountDownEvent(PlayerEvent.PlayheadUpdated event) {
-        if (playlistCountDownOptions != null && playlistCountDownOptions.shouldDisplay() && playlistAutoContinue && currentPlayingIndex + 1 <  playlist.getMediaListSize()) {
+        if (playlistCountDownOptions != null && playlistCountDownOptions.shouldDisplay() && playlistAutoContinue) {
             if (event.position >= playlistCountDownOptions.getTimeToShowMS()) {
                 if (kalturaPlayer.getMessageBus() == null) {
                     return;
                 }
+                int playlistSize = playlist.getMediaListSize();
+                boolean isLastMediaInPlaylist = ((currentPlayingIndex + 1) == playlistSize);
                 if (!playlistCountDownOptions.isEventSent()) {
                     log.d("SEND COUNT DOWN EVENT position = " + event.position);
                     kalturaPlayer.getMessageBus().post(new PlaylistEvent.PlaylistCountDownStart(currentPlayingIndex, playlistCountDownOptions));
                     playlistCountDownOptions.setEventSent(true);
-                    preloadNext();
+
+                    if (!isLastMediaInPlaylist || loopEnabled) {
+                        preloadNext();
+                    }
                 } else if (event.position >= Math.min(playlistCountDownOptions.getTimeToShowMS() + playlistCountDownOptions.getDurationMS(), event.duration)) {
                     kalturaPlayer.getMessageBus().post(new PlaylistEvent.PlaylistCountDownEnd(currentPlayingIndex, playlistCountDownOptions));
                     //log.d("playhead updated handlePlaylistMediaEnded");
+                    if (isLastMediaInPlaylist && !loopEnabled) {
+                        playlistCountDownOptions.setShouldDisplay(false);
+                        return;
+                    }
+                    kalturaPlayer.pause();
                     handlePlaylistMediaEnded();
                 }
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKPlaylistController.java
@@ -575,6 +575,15 @@ public class PKPlaylistController implements PlaylistController {
                 }
                 long fixedTimeToShow = (tmpCountDownOptions.getTimeToShowMS() == -1) ? event.duration - tmpCountDownOptions.getDurationMS() : tmpCountDownOptions.getTimeToShowMS();
                 playlistCountDownOptions = new CountDownOptions(fixedTimeToShow, tmpCountDownOptions.getDurationMS(), tmpCountDownOptions.shouldDisplay());
+
+                int playlistSize = playlist.getMediaListSize();
+                boolean isLastMediaInPlaylist = ((currentPlayingIndex + 1) == playlistSize);
+                if (isLastMediaInPlaylist && !loopEnabled) {
+                    if (event.position > playlistCountDownOptions.getTimeToShowMS()) {
+                        playlistCountDownOptions.setTimeToShowMS(event.position);
+                        return;
+                    }
+                }
             }
 
             if (event.position >= event.duration) {


### PR DESCRIPTION
fix behaviour to have count down in case loop enabled and last media is playing
or count down once only if no loop available o/w the listener will send the count down all the time since change media is not done