### PR TITLE
PKMediaEntryInterceptor and related

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -705,14 +705,14 @@ public abstract class KalturaPlayer {
         }
     }
 
-    public void applyMediaEntryInterceptors(PKMediaEntry mediaEntry, OnMediaInterceptorListener listener) {
+    public void applyMediaEntryInterceptors(PKMediaEntry mediaEntry, PKMediaEntryInterceptor.Listener listener) {
         List<PKMediaEntryInterceptor> localInterceptors = pkPlayer.getLoadedPluginsByType(PKMediaEntryInterceptor.class);
         applyMediaEntryInterceptor(localInterceptors, mediaEntry, listener);
     }
 
     private void applyMediaEntryInterceptor(List<PKMediaEntryInterceptor> localInterceptors,
                                             PKMediaEntry mediaEntry,
-                                            OnMediaInterceptorListener listener) {
+                                            PKMediaEntryInterceptor.Listener listener) {
         if (localInterceptors.isEmpty()) {
             listener.onComplete();
             return;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -16,13 +16,11 @@ import com.kaltura.netkit.connect.executor.APIOkRequestsExecutor;
 import com.kaltura.netkit.connect.response.ResultElement;
 import com.kaltura.netkit.utils.ErrorElement;
 import com.kaltura.playkit.MessageBus;
-import com.kaltura.playkit.OnMediaInterceptorListener;
 import com.kaltura.playkit.PKController;
 import com.kaltura.playkit.PKEvent;
 import com.kaltura.playkit.PKLog;
 import com.kaltura.playkit.PKMediaConfig;
 import com.kaltura.playkit.PKMediaEntry;
-import com.kaltura.playkit.PKMediaEntryInterceptor;
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKPlaylist;
 import com.kaltura.playkit.PKPlaylistMedia;
@@ -704,15 +702,15 @@ public abstract class KalturaPlayer {
     }
 
     public void applyMediaEntryInterceptors(PKMediaEntry mediaEntry, OnMediaInterceptorListener listener) {
-        List<PKMediaEntryInterceptor> localInterceptors = pkPlayer.getLoadedPluginsOfType(PKMediaEntryInterceptor.class);
+        List<PKMediaEntryInterceptor> localInterceptors = pkPlayer.getLoadedPluginsByType(PKMediaEntryInterceptor.class);
         applyMediaEntryInterceptor(localInterceptors, mediaEntry, listener);
     }
 
     private void applyMediaEntryInterceptor(List<PKMediaEntryInterceptor> localInterceptors,
                                             PKMediaEntry mediaEntry,
                                             OnMediaInterceptorListener listener) {
-        if (localInterceptors.size() == 0) {
-            listener.onApplyMediaCompleted();
+        if (localInterceptors.isEmpty()) {
+            listener.onComplete();
             return;
         }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -687,13 +687,10 @@ public abstract class KalturaPlayer {
 
         final PKMediaEntry entry = response.getResponse();
         if (entry != null) {
-            pkPlayer.applyMediaEntryInterceptors(entry, error ->
+            pkPlayer.applyMediaEntryInterceptors(entry, () ->
                     mainHandler.post(() -> {
                         setMedia(entry);
-                        if (error == null)
-                            onEntryLoadListener.onEntryLoadComplete(entry, null);
-                        else
-                            onEntryLoadListener.onEntryLoadComplete(null, new ErrorElement(error.message, 400));
+                        onEntryLoadListener.onEntryLoadComplete(entry, response.getError());
                     }));
         } else {
             onEntryLoadListener.onEntryLoadComplete(null, response.getError());

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -140,7 +140,7 @@ public abstract class KalturaPlayer {
 
     private boolean kavaPartnerIdIsMissing(PlayerInitOptions initOptions) {
         return (initOptions.tvPlayerParams == null ||
-                (initOptions.tvPlayerParams instanceof PhoenixTVPlayerParams && ((PhoenixTVPlayerParams)initOptions.tvPlayerParams).ovpPartnerId == null));
+                (initOptions.tvPlayerParams instanceof PhoenixTVPlayerParams && ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId == null));
     }
 
     protected static String safeServerUrl(Type tvPlayerType, String url, String defaultUrl) {
@@ -157,7 +157,7 @@ public abstract class KalturaPlayer {
         }
 
         if (serviceURL != null && !serviceURL.endsWith(File.separator)) {
-            serviceURL =  serviceURL + File.separator;
+            serviceURL = serviceURL + File.separator;
         }
         return serviceURL;
     }
@@ -403,7 +403,7 @@ public abstract class KalturaPlayer {
 
         ViewGroup.LayoutParams params = pkPlayer.getView().getLayoutParams();
         if (params != null) {
-            params.width  = playerWidth;
+            params.width = playerWidth;
             params.height = playerHeight;
             pkPlayer.getView().setLayoutParams(params);
         }
@@ -525,7 +525,7 @@ public abstract class KalturaPlayer {
             pkPlayer.destroy();
         }
 
-        if (playlistController  != null) {
+        if (playlistController != null) {
             playlistController.release();
             playlistController = null;
         }
@@ -544,13 +544,13 @@ public abstract class KalturaPlayer {
         if (prepareState == PrepareState.not_prepared) {
             prepare();
         }
-        if(pkPlayer != null) {
+        if (pkPlayer != null) {
             pkPlayer.play();
         }
     }
 
     public void pause() {
-        if(pkPlayer != null) {
+        if (pkPlayer != null) {
             pkPlayer.pause();
         }
     }
@@ -660,7 +660,7 @@ public abstract class KalturaPlayer {
     }
 
     public int getPartnerId() {
-        return (initOptions.partnerId != null) ?  initOptions.partnerId : 0;
+        return (initOptions.partnerId != null) ? initOptions.partnerId : 0;
     }
 
     public String getKS() {
@@ -686,12 +686,18 @@ public abstract class KalturaPlayer {
     private void mediaLoadCompleted(final ResultElement<PKMediaEntry> response, final OnEntryLoadListener onEntryLoadListener) {
 
         final PKMediaEntry entry = response.getResponse();
-        mainHandler.post(() -> {
-            if (entry != null) {
-                setMedia(entry);
-            }
-            onEntryLoadListener.onEntryLoadComplete(entry, response.getError());
-        });
+        if (entry != null) {
+            pkPlayer.applyMediaEntryInterceptors(entry, error ->
+                    mainHandler.post(() -> {
+                        setMedia(entry);
+                        if (error == null)
+                            onEntryLoadListener.onEntryLoadComplete(entry, null);
+                        else
+                            onEntryLoadListener.onEntryLoadComplete(null, new ErrorElement(error.message, 400));
+                    }));
+        } else {
+            onEntryLoadListener.onEntryLoadComplete(null, response.getError());
+        }
     }
 
     private void playlistLoadCompleted(final ResultElement<PKPlaylist> response, final OnPlaylistLoadListener onPlaylistLoadListener) {
@@ -727,8 +733,8 @@ public abstract class KalturaPlayer {
             this.partnerId = initOptions.partnerId;
             if (Type.ott.equals(tvPlayerType)) {
                 this.ovpPartnerId = (initOptions.tvPlayerParams != null &&
-                        ((PhoenixTVPlayerParams)initOptions.tvPlayerParams).ovpPartnerId != null &&
-                        ((PhoenixTVPlayerParams)initOptions.tvPlayerParams).ovpPartnerId > 0) ? ((PhoenixTVPlayerParams)initOptions.tvPlayerParams).ovpPartnerId : null;
+                        ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId != null &&
+                        ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId > 0) ? ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId : null;
             } else {
                 this.ovpPartnerId = initOptions.partnerId;
             }
@@ -886,7 +892,7 @@ public abstract class KalturaPlayer {
         }
 
         List<PKPlaylistMedia> playlistMediaEntryList = new ArrayList<>();
-        for (int i = 0; i < playlistOptions.basicMediaOptionsList.size() ; i++) {
+        for (int i = 0; i < playlistOptions.basicMediaOptionsList.size(); i++) {
             playlistMediaEntryList.add(new BasicMediaOptions(playlistOptions.basicMediaOptionsList.get(i).getPKMediaEntry()));
         }
 
@@ -895,7 +901,7 @@ public abstract class KalturaPlayer {
                 .setName(playlistOptions.playlistMetadata.getName())
                 .setDescription(playlistOptions.playlistMetadata.getDescription())
                 .setThumbnailUrl(playlistOptions.playlistMetadata.getThumbnailUrl());
-        ((PKBasicPlaylist)basicPlaylist).setBasicMediaOptionsList(playlistMediaEntryList);
+        ((PKBasicPlaylist) basicPlaylist).setBasicMediaOptionsList(playlistMediaEntryList);
 
         PlaylistController playlistController = new PKPlaylistController(KalturaPlayer.this, basicPlaylist, PKPlaylistType.BASIC_LIST);
         playlistController.setPlaylistOptions(playlistOptions);
@@ -1052,13 +1058,13 @@ public abstract class KalturaPlayer {
 
     private PhoenixAnalyticsConfig getPhoenixAnalyticsConfig() {
         String name = PhoenixAnalyticsPlugin.factory.getName();
-        if (getInitOptions() != null ) {
+        if (getInitOptions() != null) {
             PKPluginConfigs pkPluginConfigs = getInitOptions().pluginConfigs;
             if (pkPluginConfigs != null && pkPluginConfigs.hasConfig(name)) {
                 return (PhoenixAnalyticsConfig) pkPluginConfigs.getPluginConfig(name);
             }
         }
-        return  new PhoenixAnalyticsConfig(getPartnerId(), getServerUrl(), getKS(), Consts.DEFAULT_ANALYTICS_TIMER_INTERVAL_HIGH_SEC);
+        return new PhoenixAnalyticsConfig(getPartnerId(), getServerUrl(), getKS(), Consts.DEFAULT_ANALYTICS_TIMER_INTERVAL_HIGH_SEC);
     }
 
     public interface OnEntryLoadListener {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KnownPlugin.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KnownPlugin.java
@@ -25,8 +25,10 @@ enum KnownPlugin {
     // Faceboook
     fbads("com.kaltura.playkit.plugins.fbads.fbinstream.FBInstreamPlugin"),
     // Youbora
-    youbora("com.kaltura.playkit.plugins.youbora.YouboraPlugin");
-    
+    youbora("com.kaltura.playkit.plugins.youbora.YouboraPlugin"),
+    // Broadpeak
+    broadpeak("com.kaltura.playkit.plugins.broadpeak.BroadpeakPlugin");
+
     private static final PKLog log = PKLog.get("KnownPlugin");
 
     public final String className;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OnMediaInterceptorListener.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OnMediaInterceptorListener.java
@@ -1,5 +1,0 @@
-package com.kaltura.tvplayer;
-
-public interface OnMediaInterceptorListener {
-    void onComplete();
-}

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OnMediaInterceptorListener.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OnMediaInterceptorListener.java
@@ -1,0 +1,5 @@
+package com.kaltura.tvplayer;
+
+public interface OnMediaInterceptorListener {
+    void onComplete();
+}

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
@@ -9,3 +9,4 @@ public interface PKMediaEntryInterceptor {
         void onComplete();
     }
 }
+

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
@@ -1,0 +1,10 @@
+package com.kaltura.tvplayer;
+
+import com.kaltura.playkit.PKMediaEntry;
+
+/**
+ * Created by alex_lytvynenko on 09.11.2020.
+ */
+public interface PKMediaEntryInterceptor {
+    void apply(PKMediaEntry mediaEntry, OnMediaInterceptorListener listener);
+}

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
@@ -2,9 +2,6 @@ package com.kaltura.tvplayer;
 
 import com.kaltura.playkit.PKMediaEntry;
 
-/**
- * Created by alex_lytvynenko on 09.11.2020.
- */
 public interface PKMediaEntryInterceptor {
     void apply(PKMediaEntry mediaEntry, OnMediaInterceptorListener listener);
 }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
@@ -3,5 +3,9 @@ package com.kaltura.tvplayer;
 import com.kaltura.playkit.PKMediaEntry;
 
 public interface PKMediaEntryInterceptor {
-    void apply(PKMediaEntry mediaEntry, OnMediaInterceptorListener listener);
+    void apply(PKMediaEntry mediaEntry, Listener listener);
+
+    interface Listener {
+        void onComplete();
+    }
 }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PKMediaEntryInterceptor.java
@@ -9,4 +9,3 @@ public interface PKMediaEntryInterceptor {
         void onComplete();
     }
 }
-


### PR DESCRIPTION
- `KnownPlugin.class` - add `broadpeak` plugin declaration.
- `KalturaPlayer.class` - on `mediaLoadCompleted` method we add `applyMediaEntryInterceptors()` method to postpone `setMedia()` until all interceptors don't complete their work. Also we created a recursive method `applyMediaEntryInterceptor()` in order to iterate all the interceptors whether the operation was failed or successful, the iteration will go on. In case of an error it will be reported via `MessageBus`.