### PR TITLE
FEC-10923 Added forceWidevineL3Playback API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ notifications:
     recipients:
       - noam.tamim@kaltura.com
       - gilad.nadav@kaltura.com
+      - gourav.saxena@kaltura.com
     on_success: always
     on_failure: always

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -418,6 +418,7 @@ public abstract class KalturaPlayer {
         this.view = pkPlayer.getView();
     }
 
+    
     public void setMedia(@NonNull PKMediaEntry mediaEntry) {
         tokenResolver.update(mediaEntry, getKS());
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -327,6 +327,10 @@ public abstract class KalturaPlayer {
             pkPlayer.getSettings().forceSinglePlayerEngine(initOptions.forceSinglePlayerEngine);
         }
 
+        if (initOptions.forceWidevineL3Playback != null) {
+            pkPlayer.getSettings().forceWidevineL3Playback(initOptions.forceWidevineL3Playback);
+        }
+
         if (initOptions.cea608CaptionsEnabled != null) {
             pkPlayer.getSettings().setCea608CaptionsEnabled(initOptions.cea608CaptionsEnabled);
         }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -418,7 +418,6 @@ public abstract class KalturaPlayer {
         this.view = pkPlayer.getView();
     }
 
-    
     public void setMedia(@NonNull PKMediaEntry mediaEntry) {
         tokenResolver.update(mediaEntry, getKS());
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -84,7 +84,8 @@ public abstract class OfflineManager {
      */
     public abstract void prepareAsset(@NonNull PKMediaEntry mediaEntry,
                                       @NonNull SelectionPrefs prefs,
-                                      @NonNull PrepareCallback prepareCallback);
+                                      @NonNull PrepareCallback prepareCallback,
+                                      boolean forceWidevineL3Playback);
 
     /**
      * Prepare an asset for download. Connect to Kaltura Backend to load entry metadata, select the best source from
@@ -100,7 +101,8 @@ public abstract class OfflineManager {
      */
     public abstract void prepareAsset(@NonNull MediaOptions mediaOptions,
                                       @NonNull SelectionPrefs prefs,
-                                      @NonNull PrepareCallback prepareCallback)
+                                      @NonNull PrepareCallback prepareCallback,
+                                      boolean forceWidevineL3Playback)
             throws IllegalStateException;
 
     /**
@@ -187,8 +189,6 @@ public abstract class OfflineManager {
     public abstract void setEstimatedHlsAudioBitrate(int bitrate);
 
     public abstract void setLicenseRequestAdapter(PKRequestParams.Adapter licenseRequestAdapter);
-
-    public abstract void forceWidevineL3Playback(boolean forceWidevineL3Playback);
 
     public enum AssetDownloadState {
         none, prepared, started, completed, failed, removing, paused

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -367,7 +367,6 @@ public abstract class OfflineManager {
         @Nullable public List<TrackCodec> audioCodecs;
               
         @Nullable public Integer videoBitrate;
-
         @Nullable public Integer videoHeight;
         @Nullable public Integer videoWidth;
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -84,8 +84,7 @@ public abstract class OfflineManager {
      */
     public abstract void prepareAsset(@NonNull PKMediaEntry mediaEntry,
                                       @NonNull SelectionPrefs prefs,
-                                      @NonNull PrepareCallback prepareCallback,
-                                      boolean forceWidevineL3Playback);
+                                      @NonNull PrepareCallback prepareCallback);
 
     /**
      * Prepare an asset for download. Connect to Kaltura Backend to load entry metadata, select the best source from
@@ -101,8 +100,7 @@ public abstract class OfflineManager {
      */
     public abstract void prepareAsset(@NonNull MediaOptions mediaOptions,
                                       @NonNull SelectionPrefs prefs,
-                                      @NonNull PrepareCallback prepareCallback,
-                                      boolean forceWidevineL3Playback)
+                                      @NonNull PrepareCallback prepareCallback)
             throws IllegalStateException;
 
     /**
@@ -372,7 +370,7 @@ public abstract class OfflineManager {
 
         @Nullable public List<String> audioLanguages;
         @Nullable public List<String> textLanguages;
-
+        public boolean forceWidevineL3Playback;
         public boolean allAudioLanguages;
         public boolean allTextLanguages;
         public boolean allowInefficientCodecs;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -365,8 +365,9 @@ public abstract class OfflineManager {
         @Nullable public Map<TrackCodec, Integer> codecVideoBitrates;
         @Nullable public List<TrackCodec> videoCodecs;
         @Nullable public List<TrackCodec> audioCodecs;
-
+              
         @Nullable public Integer videoBitrate;
+
         @Nullable public Integer videoHeight;
         @Nullable public Integer videoWidth;
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -188,6 +188,8 @@ public abstract class OfflineManager {
 
     public abstract void setLicenseRequestAdapter(PKRequestParams.Adapter licenseRequestAdapter);
 
+    public abstract void forceWidevineL3Playback(boolean forceWidevineL3Playback);
+
     public enum AssetDownloadState {
         none, prepared, started, completed, failed, removing, paused
     }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -186,6 +186,8 @@ public abstract class OfflineManager {
 
     public abstract void setEstimatedHlsAudioBitrate(int bitrate);
 
+    public abstract void setForceWidevineL3Playback(boolean forceWidevineL3Playback);
+
     public abstract void setLicenseRequestAdapter(PKRequestParams.Adapter licenseRequestAdapter);
 
     public enum AssetDownloadState {
@@ -371,7 +373,6 @@ public abstract class OfflineManager {
         @Nullable public List<String> audioLanguages;
         @Nullable public List<String> textLanguages;
 
-        public boolean forceWidevineL3Playback;
         public boolean allAudioLanguages;
         public boolean allTextLanguages;
         public boolean allowInefficientCodecs;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -360,16 +360,17 @@ public abstract class OfflineManager {
      * Pre-download media preferences. Used with {@link #prepareAsset(PKMediaEntry, SelectionPrefs, PrepareCallback)}.
      */
     public static class SelectionPrefs {
-        @Nullable public Integer videoBitrate;
         @Nullable public Map<TrackCodec, Integer> codecVideoBitrates;
         @Nullable public List<TrackCodec> videoCodecs;
         @Nullable public List<TrackCodec> audioCodecs;
 
+        @Nullable public Integer videoBitrate;
         @Nullable public Integer videoHeight;
         @Nullable public Integer videoWidth;
 
         @Nullable public List<String> audioLanguages;
         @Nullable public List<String> textLanguages;
+
         public boolean forceWidevineL3Playback;
         public boolean allAudioLanguages;
         public boolean allTextLanguages;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -39,6 +39,7 @@ public class PlayerInitOptions {
     public Boolean vrPlayerEnabled;
     public Boolean isVideoViewHidden;
     public Boolean forceSinglePlayerEngine;
+    public Boolean forceWidevineL3Playback;
     public SubtitleStyleSettings setSubtitleStyle;
     public PKAspectRatioResizeMode aspectRatioResizeMode;
     public PKRequestParams.Adapter contentRequestAdapter;
@@ -185,6 +186,13 @@ public class PlayerInitOptions {
     public PlayerInitOptions forceSinglePlayerEngine(Boolean forceSinglePlayerEngine) {
         if (forceSinglePlayerEngine != null) {
             this.forceSinglePlayerEngine = forceSinglePlayerEngine;
+        }
+        return this;
+    }
+
+    public PlayerInitOptions forceWidevineL3Playback(Boolean forceWidevineL3Playback) {
+        if (forceWidevineL3Playback != null) {
+            this.forceWidevineL3Playback = forceWidevineL3Playback;
         }
         return this;
     }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.os.Looper;
 import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -87,7 +87,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
             throw new IllegalStateException("kalturaPartnerId and/or kalturaServerUrl not set");
         }
 
-        final MediaEntryProvider mediaEntryProvider = mediaOptions.buildMediaProvider("https://rest-as.ott.kaltura.com/v5_2_8/api_v3/", kalturaPartnerId);
+        final MediaEntryProvider mediaEntryProvider = mediaOptions.buildMediaProvider(kalturaServerUrl, kalturaPartnerId);
 
         mediaEntryProvider.load(response -> postEvent(() -> {
             if (response.isSuccess()) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -2,14 +2,17 @@ package com.kaltura.tvplayer.offline;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.Looper;
 import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.kaltura.playkit.*;
+import com.kaltura.playkit.player.MediaSupport;
 import com.kaltura.playkit.player.SourceSelector;
 import com.kaltura.playkit.providers.MediaEntryProvider;
 import com.kaltura.tvplayer.MediaOptions;
@@ -18,6 +21,8 @@ import com.kaltura.tvplayer.OfflineManager;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 public abstract class AbstractOfflineManager extends OfflineManager {
     private static final PKLog log = PKLog.get("AbstractOfflineManager");
@@ -27,6 +32,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     protected final LocalAssetsManagerExo lam;
     protected PKMediaFormat preferredMediaFormat;
     protected int estimatedHlsAudioBitrate;
+    protected boolean forceWidevineL3Playback;
     protected DownloadProgressListener downloadProgressListener;
     private AssetStateListener assetStateListener;
     private String ks;
@@ -149,6 +155,17 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     @Override
     public void setEstimatedHlsAudioBitrate(int bitrate) {
         estimatedHlsAudioBitrate = bitrate;
+    }
+
+    @Override
+    public void setForceWidevineL3Playback(boolean forceWidevineL3Playback) {
+        this.forceWidevineL3Playback = forceWidevineL3Playback;
+        if (forceWidevineL3Playback) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                Executor executor = Executors.newSingleThreadExecutor();
+                executor.execute(() -> MediaSupport.provisionWidevineL3());
+            }
+        }
     }
 
     @Override

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -205,8 +205,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         final SharedPreferences sharedPrefs = sharedPrefs();
         String pkDrmParams = sharedPrefs.getString(sharedPrefsKeyPkDrmParams(assetId), null);
         if (pkDrmParams != null) {
-            Gson pkDrmParamsGson = new Gson();
-            return pkDrmParamsGson.fromJson(pkDrmParams , PKDrmParams.class);
+            return new Gson().fromJson(pkDrmParams, PKDrmParams.class);
         }
         return null;
     }
@@ -227,8 +226,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
 
     protected void saveAssetPkDrmParams(String assetId, PKDrmParams pkDrmParams) {
         final SharedPreferences sharedPrefs = sharedPrefs();
-        Gson pkDrmParamsGson = new Gson();
-        String drmParams = pkDrmParamsGson.toJson(pkDrmParams);
+        String drmParams = new Gson().toJson(pkDrmParams);
         sharedPrefs.edit().putString(sharedPrefsKeyPkDrmParams(assetId), drmParams).apply();
     }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -8,6 +8,7 @@ import android.util.Pair;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.gson.Gson;
 import com.kaltura.playkit.*;
 import com.kaltura.playkit.player.SourceSelector;
 import com.kaltura.playkit.providers.MediaEntryProvider;
@@ -166,6 +167,14 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         return "assetSourceId:" + assetId;
     }
 
+    private String sharedPrefsKeyWidevineL3(String assetId) {
+        return "forceWidevineL3:" + assetId;
+    }
+
+    private String sharedPrefsKeyPkDrmParams(String assetId) {
+        return "pkDrmParams:" + assetId;
+    }
+
     private String loadAssetSourceId(String assetId) {
         final SharedPreferences sharedPrefs = sharedPrefs();
         return sharedPrefs.getString(sharedPrefsKey(assetId), null);
@@ -173,7 +182,17 @@ public abstract class AbstractOfflineManager extends OfflineManager {
 
     private boolean loadAssetForceWidevineL3Status(String assetId) {
         final SharedPreferences sharedPrefs = sharedPrefs();
-        return sharedPrefs.getBoolean(assetId, false);
+        return sharedPrefs.getBoolean(sharedPrefsKeyWidevineL3(assetId), false);
+    }
+
+    protected PKDrmParams loadAssetPkDrmParams(String assetId) {
+        final SharedPreferences sharedPrefs = sharedPrefs();
+        String pkDrmParams = sharedPrefs.getString(sharedPrefsKeyPkDrmParams(assetId), null);
+        if (pkDrmParams != null) {
+            Gson pkDrmParamsGson = new Gson();
+            return pkDrmParamsGson.fromJson(pkDrmParams , PKDrmParams.class);
+        }
+        return null;
     }
 
     private SharedPreferences sharedPrefs() {
@@ -187,7 +206,14 @@ public abstract class AbstractOfflineManager extends OfflineManager {
 
     protected void saveAssetForceWidevineL3Status(String assetId, boolean forceWidevineL3Playback) {
         final SharedPreferences sharedPrefs = sharedPrefs();
-        sharedPrefs.edit().putBoolean(assetId, forceWidevineL3Playback).apply();
+        sharedPrefs.edit().putBoolean(sharedPrefsKeyWidevineL3(assetId), forceWidevineL3Playback).apply();
+    }
+
+    protected void saveAssetPkDrmParams(String assetId, PKDrmParams pkDrmParams) {
+        final SharedPreferences sharedPrefs = sharedPrefs();
+        Gson pkDrmParamsGson = new Gson();
+        String drmParams = pkDrmParamsGson.toJson(pkDrmParams);
+        sharedPrefs.edit().putString(sharedPrefsKeyPkDrmParams(assetId), drmParams).apply();
     }
 
     protected void removeAssetSourceId(String assetId) {
@@ -195,7 +221,11 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     }
 
     protected void removeAssetForceWidevineL3Status(String assetId) {
-        sharedPrefs().edit().remove(assetId).apply();
+        sharedPrefs().edit().remove(sharedPrefsKeyWidevineL3(assetId)).apply();
+    }
+
+    protected void removeAssetPkDrmParams(String assetId) {
+        sharedPrefs().edit().remove(sharedPrefsKeyPkDrmParams(assetId)).apply();
     }
 
     protected @NonNull DrmStatus getDrmStatus(@NonNull String assetId, @Nullable byte[] drmInitData) {
@@ -216,7 +246,8 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     }
 
     protected boolean isForceWidevineL3Playback(String assetId) {
-        return assetId != null && loadAssetForceWidevineL3Status(assetId);
+        boolean p =   assetId != null && loadAssetForceWidevineL3Status(assetId);
+        return p;
     }
 
     @NonNull

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -23,7 +23,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
 
     protected final Context appContext;
     protected final Map<String, Pair<PKMediaSource, PKDrmParams>> pendingDrmRegistration = new HashMap<>();
-    protected final Map<String, Boolean> forceWidevineL3PlaybackMap = new HashMap<>();
     protected final LocalAssetsManagerExo lam;
     protected PKMediaFormat preferredMediaFormat;
     protected int estimatedHlsAudioBitrate;
@@ -172,6 +171,11 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         return sharedPrefs.getString(sharedPrefsKey(assetId), null);
     }
 
+    private boolean loadAssetForceWidevineL3Status(String assetId) {
+        final SharedPreferences sharedPrefs = sharedPrefs();
+        return sharedPrefs.getBoolean(assetId, false);
+    }
+
     private SharedPreferences sharedPrefs() {
         return appContext.getSharedPreferences("KalturaOfflineManager", Context.MODE_PRIVATE);
     }
@@ -181,8 +185,17 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         sharedPrefs.edit().putString(sharedPrefsKey(assetId), sourceId).apply();
     }
 
+    protected void saveAssetForceWidevineL3Status(String assetId, boolean forceWidevineL3Playback) {
+        final SharedPreferences sharedPrefs = sharedPrefs();
+        sharedPrefs.edit().putBoolean(assetId, forceWidevineL3Playback).apply();
+    }
+
     protected void removeAssetSourceId(String assetId) {
         sharedPrefs().edit().remove(sharedPrefsKey(assetId)).apply();
+    }
+
+    protected void removeAssetForceWidevineL3Status(String assetId) {
+        sharedPrefs().edit().remove(assetId).apply();
     }
 
     protected @NonNull DrmStatus getDrmStatus(@NonNull String assetId, @Nullable byte[] drmInitData) {
@@ -203,9 +216,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     }
 
     protected boolean isForceWidevineL3Playback(String assetId) {
-        return  assetId != null &&
-                forceWidevineL3PlaybackMap.containsKey(assetId) &&
-                (forceWidevineL3PlaybackMap.get(assetId) != null && forceWidevineL3PlaybackMap.get(assetId).booleanValue());
+        return  assetId != null && loadAssetForceWidevineL3Status(assetId);
     }
 
     @NonNull

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -62,7 +62,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
 
     @Override
     public final void prepareAsset(@NonNull MediaOptions mediaOptions, @NonNull SelectionPrefs prefs,
-                                   @NonNull PrepareCallback prepareCallback, boolean forceWidevineL3Playback) throws IllegalStateException {
+                                   @NonNull PrepareCallback prepareCallback) throws IllegalStateException {
 
         if (kalturaPartnerId == null || kalturaServerUrl == null) {
             throw new IllegalStateException("kalturaPartnerId and/or kalturaServerUrl not set");
@@ -74,7 +74,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
             if (response.isSuccess()) {
                 final PKMediaEntry mediaEntry = response.getResponse();
                 prepareCallback.onMediaEntryLoaded(mediaEntry.getId(), mediaEntry);
-                prepareAsset(mediaEntry, prefs, prepareCallback, forceWidevineL3Playback);
+                prepareAsset(mediaEntry, prefs, prepareCallback);
             } else {
                 prepareCallback.onMediaEntryLoadError(new IOException(response.getError().getMessage()));
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -183,10 +183,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         return "assetSourceId:" + assetId;
     }
 
-    private String sharedPrefsKeyWidevineL3(String assetId) {
-        return "forceWidevineL3:" + assetId;
-    }
-
     private String sharedPrefsKeyPkDrmParams(String assetId) {
         return "pkDrmParams:" + assetId;
     }
@@ -194,11 +190,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     private String loadAssetSourceId(String assetId) {
         final SharedPreferences sharedPrefs = sharedPrefs();
         return sharedPrefs.getString(sharedPrefsKey(assetId), null);
-    }
-
-    private boolean loadAssetForceWidevineL3Status(String assetId) {
-        final SharedPreferences sharedPrefs = sharedPrefs();
-        return sharedPrefs.getBoolean(sharedPrefsKeyWidevineL3(assetId), false);
     }
 
     protected PKDrmParams loadAssetPkDrmParams(String assetId) {
@@ -219,11 +210,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         sharedPrefs.edit().putString(sharedPrefsKey(assetId), sourceId).apply();
     }
 
-    protected void saveAssetForceWidevineL3Status(String assetId, boolean forceWidevineL3Playback) {
-        final SharedPreferences sharedPrefs = sharedPrefs();
-        sharedPrefs.edit().putBoolean(sharedPrefsKeyWidevineL3(assetId), forceWidevineL3Playback).apply();
-    }
-
     protected void saveAssetPkDrmParams(String assetId, PKDrmParams pkDrmParams) {
         final SharedPreferences sharedPrefs = sharedPrefs();
         String drmParams = new Gson().toJson(pkDrmParams);
@@ -234,10 +220,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         sharedPrefs().edit().remove(sharedPrefsKey(assetId)).apply();
     }
 
-    protected void removeAssetForceWidevineL3Status(String assetId) {
-        sharedPrefs().edit().remove(sharedPrefsKeyWidevineL3(assetId)).apply();
-    }
-
     protected void removeAssetPkDrmParams(String assetId) {
         sharedPrefs().edit().remove(sharedPrefsKeyPkDrmParams(assetId)).apply();
     }
@@ -246,7 +228,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         if (drmInitData == null) {
             return DrmStatus.clear;
         }
-        final LocalAssetsManager.AssetStatus assetStatus = lam.getDrmStatus(assetId, drmInitData, isForceWidevineL3Playback(assetId));
+        final LocalAssetsManager.AssetStatus assetStatus = lam.getDrmStatus(assetId, drmInitData, forceWidevineL3Playback);
 
         if (assetStatus == null || !assetStatus.registered) {
             return DrmStatus.unknown;
@@ -257,10 +239,6 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         }
 
         return DrmStatus.withDrm(assetStatus.licenseDuration, assetStatus.totalDuration);
-    }
-
-    protected boolean isForceWidevineL3Playback(String assetId) {
-        return assetId != null && loadAssetForceWidevineL3Status(assetId);
     }
 
     @NonNull
@@ -290,7 +268,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
                 postEvent(() -> getListener().onRegisterError(assetId, new LocalAssetsManager.RegisterException("drmInitData = null", null)));
                 return;
             }
-            lam.registerWidevineDashAsset(assetId, drmParams.getLicenseUri(), drmInitData, isForceWidevineL3Playback(assetId));
+            lam.registerWidevineDashAsset(assetId, drmParams.getLicenseUri(), drmInitData, forceWidevineL3Playback);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, drmInitData)));
         } catch (LocalAssetsManager.RegisterException | IOException | InterruptedException e) {
             postEvent(() -> getListener().onRegisterError(assetId, e));

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/AbstractOfflineManager.java
@@ -163,7 +163,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
         if (forceWidevineL3Playback) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 Executor executor = Executors.newSingleThreadExecutor();
-                executor.execute(() -> MediaSupport.provisionWidevineL3());
+                executor.execute(MediaSupport::provisionWidevineL3);
             }
         }
     }
@@ -263,8 +263,7 @@ public abstract class AbstractOfflineManager extends OfflineManager {
     }
 
     protected boolean isForceWidevineL3Playback(String assetId) {
-        boolean p =   assetId != null && loadAssetForceWidevineL3Status(assetId);
-        return p;
+        return assetId != null && loadAssetForceWidevineL3Status(assetId);
     }
 
     @NonNull

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -167,7 +167,9 @@ public class DTGOfflineManager extends AbstractOfflineManager {
                 } else {
                     postEvent(() -> prepareCallback.onPrepared(assetId, new DTGAssetInfo(item, AssetDownloadState.prepared), null));
                     pendingDrmRegistration.put(assetId, new Pair<>(source, drmData));
-                    saveAssetPkDrmParams(assetId, drmData);
+                    if (drmData != null) {
+                        saveAssetPkDrmParams(assetId, drmData);
+                    }
                     saveAssetForceWidevineL3Status(assetId, forceWidevineL3Playback);
                 }
                 cm.removeDownloadStateListener(this);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -108,7 +108,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
     @Override
     public void stop() {
-        forceWidevineL3PlaybackMap.clear();
         cm.stop();
     }
 
@@ -169,7 +168,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
                 } else {
                     postEvent(() -> prepareCallback.onPrepared(assetId, new DTGAssetInfo(item, AssetDownloadState.prepared), null));
                     pendingDrmRegistration.put(assetId, new Pair<>(source, drmData));
-                    forceWidevineL3PlaybackMap.put(assetId, forceWidevineL3Playback);
+                    saveAssetForceWidevineL3Status(assetId, forceWidevineL3Playback);
                 }
                 cm.removeDownloadStateListener(this);
             }
@@ -232,7 +231,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
         try {
             final byte[] widevineInitData = getWidevineInitData(localFile);
-
+            log.e("Gourav from DTGOfflineManager");
             lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData, isForceWidevineL3Playback(assetId));
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));
 
@@ -290,7 +289,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         final byte[] drmInitData = getWidevineInitDataOrNull(localFile);
         lam.unregisterAsset(assetId, drmInitData);
         cm.removeItem(assetId);
-        forceWidevineL3PlaybackMap.remove(assetId);
+        removeAssetForceWidevineL3Status(assetId);
         removeAssetSourceId(assetId);
 
         return true;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -1,6 +1,8 @@
 package com.kaltura.tvplayer.offline.dtg;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -39,7 +41,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         public void onDownloadComplete(DownloadItem item) {
             final String assetId = item.getItemId();
             postEvent(() -> getListener().onAssetDownloadComplete(assetId));
-
             registerDrmAsset(assetId, false);
         }
 
@@ -61,7 +62,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
             postEvent(() -> getListener().onStateChanged(assetId, new DTGAssetInfo(item, AssetDownloadState.started)));
 
-            postEventDelayed(() -> registerDrmAsset(assetId, true), 10000);
+            //postEventDelayed(() -> registerDrmAsset(assetId, true), 10000);
         }
 
         @Override
@@ -123,7 +124,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
     }
 
     @Override
-    public void prepareAsset(@NonNull PKMediaEntry mediaEntry, @NonNull SelectionPrefs prefs, @NonNull PrepareCallback prepareCallback, boolean forceWidevineL3Playback) {
+    public void prepareAsset(@NonNull PKMediaEntry mediaEntry, @NonNull SelectionPrefs prefs, @NonNull PrepareCallback prepareCallback) {
         SourceSelector selector = new SourceSelector(mediaEntry, preferredMediaFormat);
 
         final String assetId = mediaEntry.getId();
@@ -169,7 +170,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
                 } else {
                     postEvent(() -> prepareCallback.onPrepared(assetId, new DTGAssetInfo(item, AssetDownloadState.prepared), null));
                     pendingDrmRegistration.put(assetId, new Pair<>(source, drmData));
-                    forceWidevineL3PlaybackMap.put(assetId, forceWidevineL3Playback);
+                    forceWidevineL3PlaybackMap.put(assetId, prefs.forceWidevineL3Playback);
                 }
                 cm.removeDownloadStateListener(this);
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -209,7 +209,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         if (pair == null || pair.first == null || pair.second == null) {
             PKDrmParams pkDrmParams = loadAssetPkDrmParams(assetId);
             if (pkDrmParams == null) {
-                // no DRM or already processed
+                // not a DRM media or already processed
                 return;
             } else {
                 drmData = pkDrmParams;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -230,7 +230,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
         try {
             final byte[] widevineInitData = getWidevineInitData(localFile);
-            log.e("Gourav from DTGOfflineManager");
             lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData, isForceWidevineL3Playback(assetId));
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -231,7 +231,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         try {
             final byte[] widevineInitData = getWidevineInitData(localFile);
 
-            lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData);
+            lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData, forceWidevineL3Playback);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));
 
             pendingDrmRegistration.remove(assetId);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -60,7 +60,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
             postEvent(() -> getListener().onStateChanged(assetId, new DTGAssetInfo(item, AssetDownloadState.started)));
 
-            postEventDelayed(() -> registerDrmAsset(assetId, true), 10000);
+            postEventDelayed(() -> registerDrmAsset(assetId, true), 4000);
         }
 
         @Override
@@ -168,7 +168,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
                     postEvent(() -> prepareCallback.onPrepared(assetId, new DTGAssetInfo(item, AssetDownloadState.prepared), null));
                     pendingDrmRegistration.put(assetId, new Pair<>(source, drmData));
                     saveAssetPkDrmParams(assetId, drmData);
-                    saveAssetForceWidevineL3Status(assetId, prefs.forceWidevineL3Playback);
+                    saveAssetForceWidevineL3Status(assetId, forceWidevineL3Playback);
                 }
                 cm.removeDownloadStateListener(this);
             }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -170,7 +170,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
                     if (drmData != null) {
                         saveAssetPkDrmParams(assetId, drmData);
                     }
-                    saveAssetForceWidevineL3Status(assetId, forceWidevineL3Playback);
                 }
                 cm.removeDownloadStateListener(this);
             }
@@ -241,7 +240,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
         try {
             final byte[] widevineInitData = getWidevineInitData(localFile);
-            lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData, isForceWidevineL3Playback(assetId));
+            lam.registerWidevineDashAsset(assetId, licenseUri, widevineInitData, forceWidevineL3Playback);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));
 
             pendingDrmRegistration.remove(assetId);
@@ -299,7 +298,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         final byte[] drmInitData = getWidevineInitDataOrNull(localFile);
         lam.unregisterAsset(assetId, drmInitData);
         cm.removeItem(assetId);
-        removeAssetForceWidevineL3Status(assetId);
         removeAssetSourceId(assetId);
         removeAssetPkDrmParams(assetId);
         return true;


### PR DESCRIPTION
### Force Widevine L1 device to provision for L3

**Purpose**: Some devices' codec is known to failure if security level L1 is used. For those devices, apps has to force L1 device to provision for L3 devices. Ex: ASUS_Z00AD

**Solution**: We have exposed a flag `forceWidevineL3Playback`. If this set to `true`, we will provision the device for L3 otherwise not.

- For Playback:

	```
	PlayerInitOptions().forceSinglePlayerEngine(true);
	```

- For Offline Download:  Using `OfflineManager`
	```
        OfflineManager manager = OfflineManager.getInstance(context);
	manager.setForceWidevineL3Playback(true);
	```
	
**Note:** We recommend not to use this flag untill you know that that device is actually facing some decoder issues with security level L1. Apps can keep a database on there end based on the user's experiences. 


