### PR TITLE
FEC-10801 Low Latency Configuration

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -35,6 +35,7 @@ import com.kaltura.playkit.player.MediaSupport;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
 import com.kaltura.playkit.player.PKExternalSubtitle;
 import com.kaltura.playkit.player.PKHttpClientManager;
+import com.kaltura.playkit.player.PKLowLatencyConfig;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.plugins.kava.KavaAnalyticsConfig;
 import com.kaltura.playkit.plugins.kava.KavaAnalyticsPlugin;
@@ -442,7 +443,6 @@ public abstract class KalturaPlayer {
         }
     }
 
-
     public void setPlaylist(List<PKMediaEntry> entryList, Long startPosition) {
         externalSubtitles = null;
         if (startPosition != null) {
@@ -509,6 +509,12 @@ public abstract class KalturaPlayer {
     public void updateSubtitleStyle(SubtitleStyleSettings subtitleStyleSettings) {
         if (pkPlayer != null) {
             pkPlayer.updateSubtitleStyle(subtitleStyleSettings);
+        }
+    }
+
+    public void updatePKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        if (pkPlayer != null && pkLowLatencyConfig != null) {
+            pkPlayer.updatePKLowLatencyConfig(pkLowLatencyConfig);
         }
     }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -144,6 +144,7 @@ public abstract class KalturaPlayer {
         return (initOptions.tvPlayerParams == null ||
                 (initOptions.tvPlayerParams instanceof PhoenixTVPlayerParams && ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId == null));
     }
+    
 
     protected static String safeServerUrl(Type tvPlayerType, String url, String defaultUrl) {
         String serviceURL = url;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -322,6 +322,10 @@ public abstract class KalturaPlayer {
         if (initOptions.vrSettings != null) {
             pkPlayer.getSettings().setVRSettings(initOptions.vrSettings);
         }
+        
+        if (initOptions.pkLlLiveConfiguration != null) {
+            pkPlayer.getSettings().setLlLiveConfiguration(initOptions.pkLlLiveConfiguration);
+        }
 
         if (initOptions.forceSinglePlayerEngine != null) {
             pkPlayer.getSettings().forceSinglePlayerEngine(initOptions.forceSinglePlayerEngine);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -144,7 +144,6 @@ public abstract class KalturaPlayer {
         return (initOptions.tvPlayerParams == null ||
                 (initOptions.tvPlayerParams instanceof PhoenixTVPlayerParams && ((PhoenixTVPlayerParams) initOptions.tvPlayerParams).ovpPartnerId == null));
     }
-    
 
     protected static String safeServerUrl(Type tvPlayerType, String url, String defaultUrl) {
         String serviceURL = url;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -323,8 +323,8 @@ public abstract class KalturaPlayer {
             pkPlayer.getSettings().setVRSettings(initOptions.vrSettings);
         }
         
-        if (initOptions.pkLlLiveConfiguration != null) {
-            pkPlayer.getSettings().setLlLiveConfiguration(initOptions.pkLlLiveConfiguration);
+        if (initOptions.pkLowLatencyConfig != null) {
+            pkPlayer.getSettings().setPKLowLatencyConfig(initOptions.pkLowLatencyConfig);
         }
 
         if (initOptions.forceSinglePlayerEngine != null) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -10,7 +10,7 @@ import com.kaltura.playkit.PKWakeMode;
 import com.kaltura.playkit.player.AudioCodecSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
-import com.kaltura.playkit.player.PKLlLiveConfiguration;
+import com.kaltura.playkit.player.PKLowLatencyConfig;
 import com.kaltura.playkit.player.PKMaxVideoSize;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.player.VideoCodecSettings;
@@ -48,7 +48,7 @@ public class PlayerInitOptions {
     public LoadControlBuffers loadControlBuffers;
     public ABRSettings abrSettings;
     public VRSettings vrSettings;
-    public PKLlLiveConfiguration pkLlLiveConfiguration;
+    public PKLowLatencyConfig pkLowLatencyConfig;
     public Boolean cea608CaptionsEnabled;
     public Boolean mpgaAudioFormatEnabled;
     public Boolean useTextureView;
@@ -178,9 +178,9 @@ public class PlayerInitOptions {
         return this;
     }
 
-    public PlayerInitOptions setLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
-        if (pkLlLiveConfiguration != null) {
-            this.pkLlLiveConfiguration = pkLlLiveConfiguration;
+    public PlayerInitOptions setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
+        if (pkLowLatencyConfig != null) {
+            this.pkLowLatencyConfig = pkLowLatencyConfig;
         }
         return this;
     }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -10,6 +10,7 @@ import com.kaltura.playkit.PKWakeMode;
 import com.kaltura.playkit.player.AudioCodecSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
 import com.kaltura.playkit.player.PKAspectRatioResizeMode;
+import com.kaltura.playkit.player.PKLlLiveConfiguration;
 import com.kaltura.playkit.player.PKMaxVideoSize;
 import com.kaltura.playkit.player.SubtitleStyleSettings;
 import com.kaltura.playkit.player.VideoCodecSettings;
@@ -47,6 +48,7 @@ public class PlayerInitOptions {
     public LoadControlBuffers loadControlBuffers;
     public ABRSettings abrSettings;
     public VRSettings vrSettings;
+    public PKLlLiveConfiguration pkLlLiveConfiguration;
     public Boolean cea608CaptionsEnabled;
     public Boolean mpgaAudioFormatEnabled;
     public Boolean useTextureView;
@@ -172,6 +174,13 @@ public class PlayerInitOptions {
     public PlayerInitOptions setVRSettings(VRSettings vrSettings) {
         if (vrSettings != null) {
             this.vrSettings = vrSettings;
+        }
+        return this;
+    }
+
+    public PlayerInitOptions setLlLiveConfiguration(PKLlLiveConfiguration pkLlLiveConfiguration) {
+        if (pkLlLiveConfiguration != null) {
+            this.pkLlLiveConfiguration = pkLlLiveConfiguration;
         }
         return this;
     }


### PR DESCRIPTION
### Description of the Changes

- This API is dedicated only for Live and DVRLive Medias.

To set the Low Latency,
```java
playerInitOptions.setPKLowLatencyConfig(pkLowLatencyConfig
                    .setTargetOffsetMs(15000L).setMaxOffsetMs(12000L).setMaxPlaybackSpeed(4.0f));
```

To update the Low Latency,
```java
player.updatePKLowLatencyConfig(pkLowLatencyConfig
                        .setTargetOffsetMs(10000L).setMaxOffsetMs(7000L).setMaxPlaybackSpeed(1.5f));
```

**CAUTION:** If you want to use this API with Live -> VOD (While changing the media) content using the same player instance then you need to destroy the player before configuring the VOD media.