### PR TITLE
FEC-10996 Added requestConfiguration for DefaultHttpDataSource and OkHttpClient

### DIFF
--- a/tvplayer/gradle-mvn-push.gradle
+++ b/tvplayer/gradle-mvn-push.gradle
@@ -84,7 +84,7 @@ afterEvaluate { project ->
     task androidJavadocs(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-        excludes = ['**/*.kt']
+        exclude '**/*.kt'
     }
 
     afterEvaluate {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -77,6 +77,7 @@ public abstract class KalturaPlayer {
     public static final int COUNT_DOWN_INTERVAL = 100;
     public static final String OKHTTP = "okhttp";
 
+    
     static boolean playerConfigRetrieved;
 
     private static final String KALTURA_PLAYER_INIT_EXCEPTION = "KalturaPlayer.initialize() was not called or hasn't finished.";

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -77,7 +77,6 @@ public abstract class KalturaPlayer {
     public static final int COUNT_DOWN_INTERVAL = 100;
     public static final String OKHTTP = "okhttp";
 
-    
     static boolean playerConfigRetrieved;
 
     private static final String KALTURA_PLAYER_INIT_EXCEPTION = "KalturaPlayer.initialize() was not called or hasn't finished.";

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -330,6 +330,10 @@ public abstract class KalturaPlayer {
             pkPlayer.getSettings().setPKLowLatencyConfig(initOptions.pkLowLatencyConfig);
         }
 
+        if (initOptions.pkRequestConfiguration != null) {
+            pkPlayer.getSettings().setPKRequestConfig(initOptions.pkRequestConfiguration);
+        }
+
         if (initOptions.forceSinglePlayerEngine != null) {
             pkPlayer.getSettings().forceSinglePlayerEngine(initOptions.forceSinglePlayerEngine);
         }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -2,6 +2,7 @@ package com.kaltura.tvplayer;
 
 import com.kaltura.playkit.PKMediaFormat;
 import com.kaltura.playkit.PKPluginConfigs;
+import com.kaltura.playkit.PKRequestConfiguration;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
@@ -49,6 +50,7 @@ public class PlayerInitOptions {
     public ABRSettings abrSettings;
     public VRSettings vrSettings;
     public PKLowLatencyConfig pkLowLatencyConfig;
+    public PKRequestConfiguration pkRequestConfiguration;
     public Boolean cea608CaptionsEnabled;
     public Boolean mpgaAudioFormatEnabled;
     public Boolean useTextureView;
@@ -122,6 +124,11 @@ public class PlayerInitOptions {
         return this;
     }
 
+    /**
+     * This method is deprecated.
+     * Please use {@link com.kaltura.playkit.PKRequestConfiguration} to set crossProtocolRedirect
+     */
+    @Deprecated
     public PlayerInitOptions setAllowCrossProtocolEnabled(Boolean allowCrossProtocolEnabled) {
         if (allowCrossProtocolEnabled != null) {
             this.allowCrossProtocolEnabled = allowCrossProtocolEnabled;
@@ -181,6 +188,13 @@ public class PlayerInitOptions {
     public PlayerInitOptions setPKLowLatencyConfig(PKLowLatencyConfig pkLowLatencyConfig) {
         if (pkLowLatencyConfig != null) {
             this.pkLowLatencyConfig = pkLowLatencyConfig;
+        }
+        return this;
+    }
+    
+    public PlayerInitOptions setPKRequestConfig(PKRequestConfiguration pkRequestConfiguration) {
+        if (pkRequestConfiguration != null) {
+            this.pkRequestConfiguration = pkRequestConfiguration;
         }
         return this;
     }


### PR DESCRIPTION
- Marked `setAllowCrossProtocolEnabled` deprecated

Example:
`playerInitOptions.setPKRequestConfig(new PKRequestConfiguration(...));`

Deprecated Player Setting:
`playerInitOptions.setAllowCrossProtocolRedirect();`