### PR TITLE
FEC-11478 Removed non null from exception  

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/OfflineManager.java
@@ -300,7 +300,7 @@ public abstract class OfflineManager {
          * @param assetId String
          * @param error Exception
          */
-        void onPrepareError(@NonNull String assetId, OfflineManager.DownloadType downloadType, @NonNull Exception error);
+        void onPrepareError(@NonNull String assetId, OfflineManager.DownloadType downloadType, Exception error);
 
         /**
          * Called when loading a {@link PKMediaEntry} object from the backend has succeeded. It allows the app to

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -191,8 +191,8 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         final DTGListener listener = new DTGListener() {
             @Override
             public void onDownloadMetadata(DownloadItem item, Exception error) {
-                if (!TextUtils.equals(item.getItemId(), assetId))  {
-                    postEvent(() -> prepareCallback.onPrepareError(assetId, DownloadType.FULL, error));
+                if (!TextUtils.equals(item.getItemId(), assetId) && error != null)  {
+                    //postEvent(() -> prepareCallback.onPrepareError(assetId, DownloadType.FULL, error));
                     return; // wrong item - could be a matter of timing
                 }
 


### PR DESCRIPTION
 - This is not required because we do send null from DownladMetaData executor

- Removed unwanted callback in case of id mismatch