### PR TITLE
FEC-11518 Fix the edge case for track filter  - return the last track incase filter is empty - means that given val is > max in stream

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGTrackSelection.kt
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGTrackSelection.kt
@@ -294,7 +294,7 @@ class DTGTrackSelection(
 
         val filtered = sorted.filter(predicate)
 
-        return if (filtered.isEmpty()) sorted.subList(0, 1) else filtered
+        return if (filtered.isEmpty()) sorted.asReversed().subList(0, 1) else filtered
     }
 
     private fun Track.usesUnsupportedCodecs(): Boolean {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/exo/ExoPlayerTrackSelection.kt
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/exo/ExoPlayerTrackSelection.kt
@@ -351,7 +351,7 @@ class ExoPlayerTrackSelection(
 
         val sorted = tracks.sortedWith(comparator)
         val filtered = sorted.filter(predicate)
-        return if (filtered.isEmpty()) sorted.subList(0, 1) else filtered
+        return if (filtered.isEmpty()) sorted.asReversed().subList(0, 1) else filtered
     }
 
     private fun TrackCodec.isAllowed() = when (this) {


### PR DESCRIPTION
- Taking the max value available for filtering in case if the given value is beyond the max instream