### PR TITLE
 FEC-11577 AdLayout Configuration

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
-  - oraclejdk8 
+   - openjdk11
 before_install:
    - curl https://kaltura.github.io/fe-tools/android/license.sh | sh

--- a/tvplayer/build.gradle
+++ b/tvplayer/build.gradle
@@ -62,5 +62,5 @@ repositories {
 if (!ext.libVersion.contains('dev')) {
     apply from: './gradle-mvn-push.gradle'
 } else {
-    apply from: './gradle-mvn-push.local'
+    apply from: './gradle-mvn-local.gradle'
 }

--- a/tvplayer/build.gradle
+++ b/tvplayer/build.gradle
@@ -61,4 +61,6 @@ repositories {
 
 if (!ext.libVersion.contains('dev')) {
     apply from: './gradle-mvn-push.gradle'
+} else {
+    apply from: './gradle-mvn-push.local'
 }

--- a/tvplayer/gradle-mvn-local.gradle
+++ b/tvplayer/gradle-mvn-local.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'maven-publish'
+
+task androidSourcesJar(type: Jar) {
+    classifier 'sources'
+    from android.sourceSets.main.java.sourceFiles
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.release
+            }
+        }
+        repositories {
+            mavenLocal()
+        }
+    }
+}

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -531,7 +531,7 @@ public abstract class KalturaPlayer {
         }
 
         if (mediaEntry == null) {
-            log.w("playser prepare was called with null mediaEntry");
+            log.w("player prepare was called with null mediaEntry");
             return;
         }
 
@@ -540,7 +540,7 @@ public abstract class KalturaPlayer {
                 .setStartPosition(startPosition);
 
         pkPlayer.setAdvertising(advertisingConfig, getPkAdvertisingController());
-        getPkAdvertisingController().setPlayer(pkPlayer, messageBus);
+        getPkAdvertisingController().setPlayer(pkPlayer, messageBus, config);
 
         pkPlayer.prepare(config);
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -565,7 +565,7 @@ public abstract class KalturaPlayer {
         }
     }
 
-    public @Nullable PKAdvertising getAdvertisingController() {
+    public @NonNull PKAdvertising getAdvertisingController() {
         return pkAdvertisingController;
     }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -593,8 +593,8 @@ public abstract class KalturaPlayer {
                 .setStartPosition(startPosition);
 
         if (pkAdvertisingController != null && advertisingConfig != null) {
-            pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
             pkAdvertisingController.setPlayer(pkPlayer, messageBus);
+            pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
         }
 
         pkPlayer.prepare(config);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -1335,14 +1335,14 @@ public abstract class KalturaPlayer {
     }
 
     /**
-     * Advertising Configuration with JSON
+     * Advertising Configuration
      * Set null in case if App does not want to configure anything
      * for the next media playback (ChangeMedia)
      *
      * *WARNING*: In case if app is passing object null for the changeMedia
      * and IMAConfig is set with the adTag then ad will be picked from IMAConfig
      *
-     * @param advertising AdvertisingConfig Object {@link com.kaltura.playkit.ads.AdvertisingConfig} or JSON
+     * @param advertising {@link com.kaltura.playkit.ads.AdvertisingConfig} Object or {@link com.kaltura.playkit.ads.AdvertisingConfig} JSON
      */
     public void setAdvertisingConfig(@Nullable Object advertising) {
         log.d("setAdvertisingConfig");

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -563,13 +563,8 @@ public abstract class KalturaPlayer {
         pkPlayer.prepare(config);
 
         if (pkAdvertisingController != null) {
-            pkAdvertisingController.playAdNow();
+            pkAdvertisingController.playAdvertising();
         }
-
-//        if (advertisingConfig != null) {
-//            log.d("Gourav: advertisingConfig");
-//            checkAndPlayAdvertising();
-//        }
 
         prepareState = PrepareState.preparing;
         pkPlayer.addListener(this, PlayerEvent.canPlay, new PKEvent.Listener<PlayerEvent>() {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -132,7 +132,6 @@ public abstract class KalturaPlayer {
     private OfflineManager offlineManager;
     private @Nullable AdvertisingConfig advertisingConfig;
 
-    
     KalturaPlayer(Context context, Type tvPlayerType, PlayerInitOptions initOptions) {
 
         this.context = context;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -643,6 +643,7 @@ public abstract class KalturaPlayer {
         advertisingConfig = null;
         messageBus = null;
     }
+    
 
     public void stop() {
         pkPlayer.stop();

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -636,6 +636,10 @@ public abstract class KalturaPlayer {
             playlistController.release();
             playlistController = null;
         }
+        if (pkAdvertisingController != null) {
+            pkAdvertisingController.release();
+            pkAdvertisingController = null;
+        }
         messageBus = null;
     }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -495,66 +495,6 @@ public abstract class KalturaPlayer {
         }
     }
 
-    private PKAdvertisingController getPkAdvertisingController() {
-        if (pkAdvertisingController == null) {
-            pkAdvertisingController = new PKAdvertisingController();
-        }
-        return pkAdvertisingController;
-    }
-
-    /**
-     * Advertising Configuration with JSON
-     * @param advertisingJson AdvertisingConfig JSON
-     */
-    public void setAdvertisingConfig(@Nullable String advertisingJson) {
-        if (TextUtils.isEmpty(advertisingJson)) {
-            log.w("Advertising config is empty. Hence clearing the current advertising config.");
-            this.advertisingConfig = null;
-            return;
-        }
-
-        if (this.advertisingConfig != null) {
-            this.advertisingConfig = null;
-        }
-
-        String imaPlugin = KnownPlugin.ima.name();
-        if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
-            AdvertisingConfig advertisingConfig = new Gson().fromJson(advertisingJson, AdvertisingConfig.class);
-            if (advertisingConfig != null) {
-                this.advertisingConfig = advertisingConfig;
-            } else {
-                log.w("Malformed AdvertisingConfig Json");
-            }
-        } else {
-            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
-                    "You can pass empty adtag url while configuring IMAPlugin");
-        }
-    }
-
-    /**
-     * Advertising Configuration with AdvertisingConfig object
-     * @param advertisingConfig AdvertisingConfig object
-     */
-    public void setAdvertisingConfig(@Nullable AdvertisingConfig advertisingConfig) {
-        if (advertisingConfig == null) {
-            log.w("Advertising config is null. Hence clearing the current advertising config.");
-            this.advertisingConfig = null;
-            return;
-        }
-
-        if (this.advertisingConfig != null) {
-            this.advertisingConfig = null;
-        }
-
-        String imaPlugin = KnownPlugin.ima.name();
-        if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
-            this.advertisingConfig = advertisingConfig;
-        } else {
-            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
-                    "You can pass empty adtag url while configuring IMAPlugin");
-        }
-    }
-
     public void setPlaylist(List<PKMediaEntry> entryList, Long startPosition) {
         if (entryList == null || entryList.isEmpty()) {
             log.e("entryList does not contain any source");
@@ -1386,6 +1326,74 @@ public abstract class KalturaPlayer {
         }
 
         NetworkUtils.sendKavaAnalytics(context, partnerId, entryId, NetworkUtils.KAVA_EVENT_PLAY_REQUEST, sessionId);
+    }
+
+    private PKAdvertisingController getPkAdvertisingController() {
+        if (pkAdvertisingController == null) {
+            pkAdvertisingController = new PKAdvertisingController();
+        }
+        return pkAdvertisingController;
+    }
+
+    /**
+     * Advertising Configuration with JSON
+     * Set null in case if App does not want to configure anything
+     * for the next media playback (ChangeMedia)
+     *
+     * @param advertisingJson AdvertisingConfig JSON
+     */
+    public void setAdvertisingConfig(@Nullable String advertisingJson) {
+        log.d("setAdvertisingConfig Json");
+        if (TextUtils.isEmpty(advertisingJson)) {
+            log.d("Advertising config is empty. Hence clearing the current advertising config.");
+            this.advertisingConfig = null;
+            return;
+        }
+
+        if (this.advertisingConfig != null) {
+            this.advertisingConfig = null;
+        }
+
+        String imaPlugin = KnownPlugin.ima.name();
+        if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
+            AdvertisingConfig advertisingConfig = new Gson().fromJson(advertisingJson, AdvertisingConfig.class);
+            if (advertisingConfig != null) {
+                this.advertisingConfig = advertisingConfig;
+            } else {
+                log.e("Malformed AdvertisingConfig Json");
+            }
+        } else {
+            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
+                    "You can pass empty adtag url while configuring IMAPlugin");
+        }
+    }
+
+    /**
+     * Advertising Configuration with AdvertisingConfig object
+     * Set null in case if App does not want to configure anything
+     * for the next media playback (ChangeMedia)
+     *
+     * @param advertisingConfig AdvertisingConfig object
+     */
+    public void setAdvertisingConfig(@Nullable AdvertisingConfig advertisingConfig) {
+        log.d("setAdvertisingConfig object");
+        if (advertisingConfig == null) {
+            log.d("Advertising config is null. Hence clearing the current advertising config.");
+            this.advertisingConfig = null;
+            return;
+        }
+
+        if (this.advertisingConfig != null) {
+            this.advertisingConfig = null;
+        }
+
+        String imaPlugin = KnownPlugin.ima.name();
+        if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
+            this.advertisingConfig = advertisingConfig;
+        } else {
+            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
+                    "You can pass empty adtag url while configuring IMAPlugin");
+        }
     }
 
     public interface OnEntryLoadListener {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -541,7 +541,7 @@ public abstract class KalturaPlayer {
                 .setStartPosition(startPosition);
 
         if (pkAdvertisingController != null) {
-            pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
+            pkPlayer.setAdvertising(pkAdvertisingController, advertisingConfig);
             pkAdvertisingController.setPlayer(pkPlayer, messageBus, config);
         }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -540,8 +540,10 @@ public abstract class KalturaPlayer {
                 .setMediaEntry(mediaEntry)
                 .setStartPosition(startPosition);
 
-        pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
-        pkAdvertisingController.setPlayer(pkPlayer, messageBus, config);
+        if (pkAdvertisingController != null) {
+            pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
+            pkAdvertisingController.setPlayer(pkPlayer, messageBus, config);
+        }
 
         pkPlayer.prepare(config);
 
@@ -554,7 +556,7 @@ public abstract class KalturaPlayer {
             }
         });
 
-        if (advertisingConfig != null) {
+        if (pkAdvertisingController != null && advertisingConfig != null) {
             pkAdvertisingController.loadAdvertising();
         }
 
@@ -1359,12 +1361,14 @@ public abstract class KalturaPlayer {
         if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
 
             if (advertising instanceof AdvertisingConfig) {
+                initializeAdvertisingController();
                 this.advertisingConfig = (AdvertisingConfig) advertising;
                 return;
             } else if (advertising instanceof String) {
                 try {
                     AdvertisingConfig advertisingConf = new Gson().fromJson((String) advertising, AdvertisingConfig.class);
                     if (advertisingConf != null) {
+                        initializeAdvertisingController();
                         this.advertisingConfig = advertisingConf;
                         return;
                     }
@@ -1381,6 +1385,12 @@ public abstract class KalturaPlayer {
                     "You have to pass empty adTag url while configuring IMAPlugin config");
         }
         this.advertisingConfig = null;
+    }
+
+    private void initializeAdvertisingController() {
+        if (pkAdvertisingController == null) {
+            pkAdvertisingController = new PKAdvertisingController();
+        }
     }
 
     public interface OnEntryLoadListener {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.kaltura.netkit.connect.executor.APIOkRequestsExecutor;
 import com.kaltura.netkit.connect.response.ResultElement;
 import com.kaltura.netkit.utils.ErrorElement;
@@ -1360,14 +1361,18 @@ public abstract class KalturaPlayer {
 
         String imaPlugin = KnownPlugin.ima.name();
         if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
-            AdvertisingConfig advertisingConfig = new Gson().fromJson(advertisingJson, AdvertisingConfig.class);
-            if (advertisingConfig != null) {
-                this.advertisingConfig = advertisingConfig;
-            } else {
-                log.e("Malformed AdvertisingConfig Json");
+            try {
+                AdvertisingConfig advertisingConfig = new Gson().fromJson(advertisingJson, AdvertisingConfig.class);
+                if (advertisingConfig != null) {
+                    this.advertisingConfig = advertisingConfig;
+                } else {
+                    log.e("Malformed AdvertisingConfig Json");
+                }
+            } catch (JsonSyntaxException e) {
+                log.e("Malformed AdvertisingConfig Json Exception: " + e.getMessage());
             }
         } else {
-            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
+            log.e("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
                     "You can pass empty adtag url while configuring IMAPlugin");
         }
     }
@@ -1395,7 +1400,7 @@ public abstract class KalturaPlayer {
         if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
             this.advertisingConfig = advertisingConfig;
         } else {
-            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
+            log.e("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
                     "You can pass empty adtag url while configuring IMAPlugin");
         }
     }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -1344,7 +1344,6 @@ public abstract class KalturaPlayer {
      */
     public void setAdvertisingConfig(@Nullable Object advertising) {
         log.d("setAdvertisingConfig");
-        AdvertisingConfig advertisingConf;
 
         if (advertising == null) {
             log.d("Advertising config is empty. Hence clearing the current advertising config.");
@@ -1353,31 +1352,35 @@ public abstract class KalturaPlayer {
         }
 
         if (this.advertisingConfig != null) {
-            this.advertisingConfig = null;
+            this.advertisingConfig = null; // Reset the existing advertisingConfig
         }
 
         String imaPlugin = KnownPlugin.ima.name();
         if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
-            if (advertising instanceof String) {
+
+            if (advertising instanceof AdvertisingConfig) {
+                this.advertisingConfig = (AdvertisingConfig) advertising;
+                return;
+            } else if (advertising instanceof String) {
                 try {
-                    advertisingConf = new Gson().fromJson((String) advertising, AdvertisingConfig.class);
+                    AdvertisingConfig advertisingConf = new Gson().fromJson((String) advertising, AdvertisingConfig.class);
                     if (advertisingConf != null) {
                         this.advertisingConfig = advertisingConf;
-                    } else {
-                        log.e("Malformed AdvertisingConfig Json");
+                        return;
                     }
-                } catch (JsonSyntaxException e) {
-                    log.e("Malformed AdvertisingConfig Json Exception: " + e.getMessage());
+
+                    log.e("AdvertisingConfig Json String is invalid");
+                } catch (Exception e) {
+                    log.e("AdvertisingConfig Json Exception: " + e.getMessage());
                 }
-            } else if (advertising instanceof AdvertisingConfig) {
-                this.advertisingConfig = (AdvertisingConfig) advertising;
             } else {
                 log.e("Advertising Config can be set using JSON or AdvertisingConfig object");
             }
         } else {
             log.e("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
-                    "You can pass empty AdTag url or VAST response while configuring IMAPlugin");
+                    "You have to pass empty adTag url while configuring IMAPlugin config");
         }
+        this.advertisingConfig = null;
     }
 
     public interface OnEntryLoadListener {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -643,7 +643,6 @@ public abstract class KalturaPlayer {
         advertisingConfig = null;
         messageBus = null;
     }
-    
 
     public void stop() {
         pkPlayer.stop();

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -562,10 +562,6 @@ public abstract class KalturaPlayer {
 
         pkPlayer.prepare(config);
 
-        if (pkAdvertisingController != null) {
-            pkAdvertisingController.playAdvertising();
-        }
-
         prepareState = PrepareState.preparing;
         pkPlayer.addListener(this, PlayerEvent.canPlay, new PKEvent.Listener<PlayerEvent>() {
             @Override
@@ -574,6 +570,10 @@ public abstract class KalturaPlayer {
                 pkPlayer.removeListener(this);
             }
         });
+
+        if (pkAdvertisingController != null) {
+            pkAdvertisingController.playAdvertising();
+        }
 
         if (autoPlay) {
             pkPlayer.play();

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -32,7 +32,7 @@ import com.kaltura.playkit.PlayKitManager;
 import com.kaltura.playkit.Player;
 import com.kaltura.playkit.PlayerEvent;
 import com.kaltura.playkit.ads.AdController;
-import com.kaltura.playkit.ads.Advertising;
+import com.kaltura.playkit.ads.AdvertisingConfig;
 import com.kaltura.playkit.ads.PKAdvertising;
 import com.kaltura.playkit.ads.PKAdvertisingController;
 import com.kaltura.playkit.player.ABRSettings;
@@ -130,7 +130,7 @@ public abstract class KalturaPlayer {
     private PlayerInitOptions initOptions;
     private PlaylistController playlistController;
     private OfflineManager offlineManager;
-    private Advertising advertisingConfig;
+    private AdvertisingConfig advertisingConfig;
 
     KalturaPlayer(Context context, Type tvPlayerType, PlayerInitOptions initOptions) {
 
@@ -495,7 +495,7 @@ public abstract class KalturaPlayer {
         }
     }
 
-    public void setAdvertising(Advertising advertisingConfig) {
+    public void setAdvertisingConfig(AdvertisingConfig advertisingConfig) {
         if (advertisingConfig == null) {
             log.w("Advertising config should not be null.");
             return;
@@ -506,21 +506,10 @@ public abstract class KalturaPlayer {
             pkAdvertisingController = new PKAdvertisingController();
             this.advertisingConfig = advertisingConfig;
         } else {
-            log.w("IMAPlugin needs to be configured in order to use Advertsing feature. \n " +
+            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
                     "You can pass empty adtag url while configuring IMAPlugin");
         }
     }
-
-//    private void checkAndPlayAdvertising() {
-//        String imaPlugin = KnownPlugin.ima.name();
-//        if (!initOptions.pluginConfigs.hasConfig(imaPlugin)) {
-//            log.w("IMAPlugin is required to work for Advertising configuration.");
-//            return;
-//        }
-//
-//        PKAdvertisingController pkAdvertisingController = new PKAdvertisingController(KalturaPlayer.this, advertisingConfig);
-//        pkAdvertisingController.playAdNow();
-//    }
 
     public void setPlaylist(List<PKMediaEntry> entryList, Long startPosition) {
         if (entryList == null || entryList.isEmpty()) {
@@ -558,7 +547,7 @@ public abstract class KalturaPlayer {
         }
 
         if (mediaEntry == null) {
-            log.w("player prepare was called with null mediaEntry");
+            log.w("playser prepare was called with null mediaEntry");
             return;
         }
 

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -132,6 +132,7 @@ public abstract class KalturaPlayer {
     private OfflineManager offlineManager;
     private @Nullable AdvertisingConfig advertisingConfig;
 
+    
     KalturaPlayer(Context context, Type tvPlayerType, PlayerInitOptions initOptions) {
 
         this.context = context;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
 import com.kaltura.netkit.connect.executor.APIOkRequestsExecutor;
 import com.kaltura.netkit.connect.response.ResultElement;
 import com.kaltura.netkit.utils.ErrorElement;

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -557,7 +557,7 @@ public abstract class KalturaPlayer {
         });
 
         if (pkAdvertisingController != null && advertisingConfig != null) {
-            pkAdvertisingController.loadAdvertising();
+            pkAdvertisingController.loadAdvertising(startPosition);
         }
 
         if (autoPlay) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -568,7 +568,7 @@ public abstract class KalturaPlayer {
 
         if (pkAdvertisingController != null && advertisingConfig != null) {
             pkPlayer.setAdvertising(advertisingConfig, pkAdvertisingController);
-            pkAdvertisingController.setPlayer(pkPlayer);
+            pkAdvertisingController.setPlayer(pkPlayer, messageBus);
         }
 
         pkPlayer.prepare(config);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -495,10 +495,47 @@ public abstract class KalturaPlayer {
         }
     }
 
+    /**
+     * Advertising Configuration with JSON
+     * @param advertisingJson AdvertisingConfig JSON
+     */
+    public void setAdvertisingConfig(String advertisingJson) {
+        if (TextUtils.isEmpty(advertisingJson)) {
+            log.w("Advertising config should not be null.");
+            return;
+        }
+
+        if (pkAdvertisingController != null) {
+            throw new IllegalStateException("App can not configure Advertising using Object and JSON both.");
+        }
+
+        String imaPlugin = KnownPlugin.ima.name();
+        if (initOptions.pluginConfigs != null && initOptions.pluginConfigs.hasConfig(imaPlugin)) {
+            AdvertisingConfig advertisingConfig = new Gson().fromJson(advertisingJson, AdvertisingConfig.class);
+            if (advertisingConfig != null) {
+                pkAdvertisingController = new PKAdvertisingController();
+                this.advertisingConfig = advertisingConfig;
+            } else {
+                log.w("Malformed AdvertisingConfig Json");
+            }
+        } else {
+            log.w("IMAPlugin needs to be configured in order to use Advertising feature. \n " +
+                    "You can pass empty adtag url while configuring IMAPlugin");
+        }
+    }
+
+    /**
+     * Advertising Configuration with AdvertisingConfig object
+     * @param advertisingConfig AdvertisingConfig object
+     */
     public void setAdvertisingConfig(AdvertisingConfig advertisingConfig) {
         if (advertisingConfig == null) {
             log.w("Advertising config should not be null.");
             return;
+        }
+
+        if (pkAdvertisingController != null) {
+            throw new IllegalStateException("App can not configure Advertising using Object and JSON both.");
         }
 
         String imaPlugin = KnownPlugin.ima.name();


### PR DESCRIPTION
### Description of the Changes

[Works with [Playkit-IMA](https://github.com/kaltura/playkit-android-ima)]

With Ad layout config you can create your own ad break timeline using your vast tags. Ad break can be set as pre, mid and post rolls and each ad break can contain a single vast tag or multiple tags, either as a pod, but also as a Waterfall.

