### PR TITLE
FEC-12577 Fix typo for `maxAudioBitrate`

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -417,7 +417,7 @@ public abstract class KalturaPlayer {
         }
 
         if (initOptions.maxAudioBitrate != null) {
-            pkPlayer.getSettings().setMaxVideoBitrate(initOptions.maxAudioBitrate);
+            pkPlayer.getSettings().setMaxAudioBitrate(initOptions.maxAudioBitrate);
         }
 
         if (initOptions.maxAudioChannelCount != null) {

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -6,8 +6,8 @@ import com.kaltura.playkit.PKRequestConfig;
 import com.kaltura.playkit.PKRequestParams;
 import com.kaltura.playkit.PKSubtitlePreference;
 import com.kaltura.playkit.PKTrackConfig;
-import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.PKWakeMode;
+import com.kaltura.playkit.player.ABRSettings;
 import com.kaltura.playkit.player.AudioCodecSettings;
 import com.kaltura.playkit.player.DRMSettings;
 import com.kaltura.playkit.player.LoadControlBuffers;
@@ -370,6 +370,11 @@ public class PlayerInitOptions {
         return this;
     }
 
+    /**
+     * Please Use {@link #setAbrSettings(com.kaltura.playkit.player.ABRSettings)}
+     * to achieve this functionality.
+     */
+    @Deprecated
     public PlayerInitOptions setMaxVideoSize(PKMaxVideoSize maxVideoSize) {
         if (maxVideoSize != null) {
             this.maxVideoSize = maxVideoSize;
@@ -377,6 +382,11 @@ public class PlayerInitOptions {
         return this;
     }
 
+    /**
+     * Please Use {@link #setAbrSettings(com.kaltura.playkit.player.ABRSettings)}
+     * to achieve this functionality.
+     */
+    @Deprecated
     public PlayerInitOptions setMaxVideoBitrate(Integer maxVideoBitrate) {
         if (maxVideoBitrate != null) {
             this.maxVideoBitrate = maxVideoBitrate;


### PR DESCRIPTION
- Marked methods as deprecated on KalturaPlayer level. On Playkit, it is already deprecated.