### PR TITLE
FEC-12338 ExoPlayer upgrade to v2.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/tvplayer/build.gradle
+++ b/tvplayer/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     implementation "androidx.work:work-runtime:2.7.1"
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation "androidx.core:core-ktx:1.3.2"
+    implementation "androidx.core:core-ktx:1.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.4.0'
 

--- a/tvplayer/build.gradle
+++ b/tvplayer/build.gradle
@@ -4,14 +4,14 @@ apply from: 'version.gradle'
 
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -368,6 +368,10 @@ public abstract class KalturaPlayer {
             pkPlayer.getSettings().allowChunklessPreparation(initOptions.allowChunklessPreparation);
         }
 
+        if (initOptions.constrainAudioChannelCountToDeviceCapabilities != null) {
+            pkPlayer.getSettings().constrainAudioChannelCountToDeviceCapabilities(initOptions.constrainAudioChannelCountToDeviceCapabilities);
+        }
+
         if (initOptions.cea608CaptionsEnabled != null) {
             pkPlayer.getSettings().setCea608CaptionsEnabled(initOptions.cea608CaptionsEnabled);
         }

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -603,6 +603,14 @@ public abstract class KalturaPlayer {
         }
     }
 
+    @Nullable
+    public Object getCurrentMediaManifest() {
+        if (pkPlayer != null) {
+            return pkPlayer.getCurrentMediaManifest();
+        }
+        return null;
+    }
+
     public void updateSubtitleStyle(SubtitleStyleSettings subtitleStyleSettings) {
         if (pkPlayer != null) {
             pkPlayer.updateSubtitleStyle(subtitleStyleSettings);

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/PlayerInitOptions.java
@@ -47,6 +47,7 @@ public class PlayerInitOptions {
     public Boolean forceSinglePlayerEngine;
     public Boolean forceWidevineL3Playback;
     public Boolean allowChunklessPreparation = true;
+    public Boolean constrainAudioChannelCountToDeviceCapabilities;
     public DRMSettings drmSettings;
     public SubtitleStyleSettings setSubtitleStyle;
     public PKAspectRatioResizeMode aspectRatioResizeMode;
@@ -233,6 +234,13 @@ public class PlayerInitOptions {
     public PlayerInitOptions allowChunklessPreparation(Boolean allowChunklessPreparation) {
         if (allowChunklessPreparation != null) {
             this.allowChunklessPreparation = allowChunklessPreparation;
+        }
+        return this;
+    }
+
+    public PlayerInitOptions constrainAudioChannelCountToDeviceCapabilities(Boolean enabled) {
+        if (constrainAudioChannelCountToDeviceCapabilities != null) {
+            this.constrainAudioChannelCountToDeviceCapabilities = enabled;
         }
         return this;
     }


### PR DESCRIPTION
- FEC-12722 | Added `getCurrentMediaManifest` Returns `nullable` media manifest of the window. Manifest depends on the type of media being prepared. Must be called once the media preparation is complete (Means tracks are loaded)
   ```java
   Object mediaManifest = player.getCurrentMediaManifest();

   if (mediaManifest instanceOf DashManifest) {
     DashManifest manifest = (DashManifest)mediaManifest;
   } else if (mediaManifest instanceOf HlsManifest) {
     HlsManifest manifest = (HlsManifest)mediaManifest;
   }
   ```
- Updated gradle wrapper to v7.3.3
