### PR TITLE
fix(SUP-38389):Offline download DRM issues

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -65,7 +65,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
 
             postEvent(() -> getListener().onStateChanged(assetId, DownloadType.FULL, new DTGAssetInfo(item, AssetDownloadState.started)));
 
-            postEventDelayed(() -> registerDrmAsset(assetId, true), 4000);
+            postEventDelayed(() -> registerDrmAsset(assetId, true), 7000);
         }
 
         @Override
@@ -289,6 +289,7 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         }
 
         try {
+            //todo: ad change here?
             final byte[] widevineInitData = getWidevineInitData(localFile);
             lam.registerWidevineAsset(assetId, getAssetFormat(assetId), licenseUri, widevineInitData, forceWidevineL3Playback);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));

--- a/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/offline/dtg/DTGOfflineManager.java
@@ -289,7 +289,6 @@ public class DTGOfflineManager extends AbstractOfflineManager {
         }
 
         try {
-            //todo: ad change here?
             final byte[] widevineInitData = getWidevineInitData(localFile);
             lam.registerWidevineAsset(assetId, getAssetFormat(assetId), licenseUri, widevineInitData, forceWidevineL3Playback);
             postEvent(() -> getListener().onRegistered(assetId, getDrmStatus(assetId, widevineInitData)));


### PR DESCRIPTION
issue:
sometimes get onRegisterError after start downloading drm

solution:
add more time after start downloading before call to initDrmData 

solve [SUP-38389](https://kaltura.atlassian.net/browse/SUP-38389)

[SUP-38389]: https://kaltura.atlassian.net/browse/SUP-38389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ