### PR TITLE
feat(KUX-152): setPreferredAudioLanguage

### DIFF
--- a/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
+++ b/tvplayer/src/main/java/com/kaltura/tvplayer/KalturaPlayer.java
@@ -1456,6 +1456,11 @@ public abstract class KalturaPlayer {
         }
     }
 
+    public void setPreferredAudioLanguage(PKTrackConfig.Mode audioMode, String audioLanguage) {
+        log.v("setPreferredAudioLanguage" + " audioMode: " + audioMode + " audioLanguage: " + audioLanguage);
+        pkPlayer.getSettings().setPreferredAudioTrack(new PKTrackConfig().setPreferredMode(audioMode).setTrackLanguage(audioLanguage));
+    }
+
     public interface OnEntryLoadListener {
         void onEntryLoadComplete(MediaOptions mediaOptions, PKMediaEntry entry, @Nullable ErrorElement error);
     }


### PR DESCRIPTION
### What's done
- [KUX-152](https://kaltura.atlassian.net/browse/KUX-152)
- add ability to change preferred audio dynamically during using the player not just during setup

### Questions
- is it safe to change the values in `pkPlayer.getSettings()` during using the player
- iOS version of the player allows to change value directly it's exposed as public. Is it correct?

[KUX-152]: https://kaltura.atlassian.net/browse/KUX-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ